### PR TITLE
Fix the composer provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "provide": {
-        "psr/container": "1.0"
+        "psr/container-implementation": "1.0"
     },
     "scripts": {
         "test": "phpunit",


### PR DESCRIPTION
This package does not provide the code of the psr/container package (which defines interfaces). It provides psr/container-implementation which is the virtual package representing implementations of the interface.
Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that installing psr/container is not necessary as it is already provided.

Refs composer/composer#9316